### PR TITLE
Added verbose mode for apply command

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Usage: marlin-console-configurator [command] [command options]
           --save, -s
             When is present, will save changes to files. Else, just display changes without saving
             Default: false
+          --verbose, -v
+            when present, all non-changed line are printed
+            Default: false
           --yes, -y
             when present, the changes will be saved without prompting the user
             Default: false

--- a/src/main/java/fr/chuckame/marlinfw/configurator/command/ApplyCommand.java
+++ b/src/main/java/fr/chuckame/marlinfw/configurator/command/ApplyCommand.java
@@ -36,6 +36,8 @@ public class ApplyCommand implements Command {
     private boolean doSave;
     @Parameter(names = {"--yes", "-y"}, description = "when present, the changes will be saved without prompting the user")
     private boolean applyWithoutPrompt;
+    @Parameter(names = {"--verbose", "-v"}, description = "when present, all non-changed line are printed")
+    private boolean verbose;
 
     private final ProfileAdapter profileAdapter;
     private final LineChangeManager lineChangeManager;
@@ -81,7 +83,7 @@ public class ApplyCommand implements Command {
                                .doOnNext(change -> consoleHelper.writeLine(lineChangeFormatter.format(change), getChangeColor(change))),
                            Flux.fromIterable(fileChanges.getValue())
                                .filter(LineChange::isConstant)
-                               .filter(c -> c.getDiff() == LineChange.DiffEnum.DO_NOTHING)
+                               .filter(c -> verbose && c.getDiff() == LineChange.DiffEnum.DO_NOTHING)
                                .doOnNext(change -> consoleHelper.writeLine(lineChangeFormatter.format(change), getChangeColor(change))),
                            Mono.fromRunnable(consoleHelper::newLine)
                    ))


### PR DESCRIPTION
Related to #6

Add optional `--verbose` (or `-v`) for `apply` command to reduce default verbose of printed changes